### PR TITLE
Identity Mutation [Milestone 1]

### DIFF
--- a/pallets/identity/src/tests.rs
+++ b/pallets/identity/src/tests.rs
@@ -86,3 +86,20 @@ fn revoke_identity_from_non_owning_account() {
         );
     });
 }
+
+#[test]
+fn add_identity_trait() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(IdentityModule::create_identity(Origin::signed(300)));
+        assert_ok!(IdentityModule::add_identity_trait(Origin::signed(300), 1, "name".as_bytes().to_vec(), "Luke Skywalker".as_bytes().to_vec()));
+    });
+}
+
+#[test]
+fn remove_identity_trait() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(IdentityModule::create_identity(Origin::signed(300)));
+        assert_ok!(IdentityModule::add_identity_trait(Origin::signed(300), 1, "name".as_bytes().to_vec(), "Luke Skywalker".as_bytes().to_vec()));
+        assert_ok!(IdentityModule::remove_identity_trait(Origin::signed(300), 1, "name".as_bytes().to_vec()));
+    });
+}


### PR DESCRIPTION
in the current implementation. `is_identity_owned_by_sender` must be called to see if `sender` is the owner of the identity being mutated. Then, during deletion or edit (not so much "insert"), the u32 identity key is searched for in `IdentityTraitList`.

If the Identity Traits were located in the `IdentityList`, it would remove the need for the additional index on `IdentityTraitList`

Also consider, if we want to allow a fetch all the traits given a u32 identity key, it will be on a single key across all identities.

Current Implementation.
```rust
#[pallet::storage]
#[pallet::getter(fn identity_trait_list)]
/// Maps identity ID numbers to their key/value attributes.
pub type IdentityTraitList<T: Config> = StorageDoubleMap<_, Blake2_128Concat, u32, Blake2_128Concat, Vec<u8>, Vec<u8>>;
```

Suggested Implementation, with the `IdentityTraitList` being removed.

```rust
#[pallet::storage]
#[pallet::getter(fn identity_list)]
/// Maps accounts to the array of identities it owns.
pub type IdentityList<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BTreeMap<u32, HashMap<Vec<u8>, Vec<u8>>>, ValueQuery>;
```

Closes #2