### PR TITLE
Cache Dependencies During GitHub Actions Build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,9 +36,8 @@ jobs:
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
 
-      - name: Check Build
-        run: |
-          SKIP_WASM_BUILD=1 cargo check --release
+      - name: Enable caching
+        uses: Swatinem/rust-cache@v1.3.0
       
       - name: Test Build
         run: >

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      
+      - name: Enable caching
+        uses: Swatinem/rust-cache@v1.3.0
+        
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout with Submodules
         uses: actions/checkout@v2
@@ -35,9 +39,6 @@ jobs:
           rustup update nightly
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
-
-      - name: Enable caching
-        uses: Swatinem/rust-cache@v1.3.0
       
       - name: Test Build
         run: >

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,9 +18,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      
-      - name: Enable caching
-        uses: Swatinem/rust-cache@v1.3.0
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout with Submodules
@@ -40,6 +37,9 @@ jobs:
           rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
       
+      - name: Enable caching
+        uses: Swatinem/rust-cache@v1.3.0
+
       - name: Test Build
         run: >
           cargo test


### PR DESCRIPTION
Cuts build/test time from ~30 minutes to ~10 minutes. 