### PR TITLE
Fixing Rust Version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env
-          rustup default nightly
-          rustup update nightly
-          rustup update stable
           rustup target add wasm32-unknown-unknown --toolchain nightly
       
       - name: Check Formatting

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,9 +41,6 @@ jobs:
         run: >
           cargo fmt --check
 
-      - name: Enable caching
-        uses: Swatinem/rust-cache@v1.3.0
-
       - name: Test Build
         run: >
           cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,10 @@ jobs:
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env
-          rustup target add wasm32-unknown-unknown --toolchain nightly
+          rustup update nightly
+          rustup update stable
+          rustup default nightly-2022-11-15
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2022-11-15
       
       - name: Check Formatting
         run: >

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64 as base
+FROM rust:1.67 as base
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -y && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install clang libclang-dev libclang1 llvm llvm-dev clang-tools -y && \
     apt-get upgrade -y
 
-RUN rustup default nightly && \
-    rustup update nightly && \
-    rustup target add wasm32-unknown-unknown --toolchain nightly
+RUN rustup update nightly && \
+    rustup default nightly-2022-11-15 && \
+    rustup target add wasm32-unknown-unknown --toolchain nightly-2022-11-15
 
 FROM base as planner
 WORKDIR app

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,5 +13,5 @@ if [ -z $CI_PROJECT_NAME ] ; then
    rustup update stable
 fi
 
-rustup override set nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup override set nightly-2022-11-15
+rustup target add wasm32-unknown-unknown --toolchain nightly-2022-11-15


### PR DESCRIPTION
Somehow, this needs to use rust-toolchain.toml, but right now we need to know that we're running on a fixed version that supports the features that Substrate currently uses.